### PR TITLE
[FIX] it should finish to development branch by default

### DIFF
--- a/src/utils/get-ancestor-branch.js
+++ b/src/utils/get-ancestor-branch.js
@@ -21,6 +21,6 @@ module.exports = {
       }
     }
 
-    return config.remoteProduction;
+    return config.remoteDevelop;
   }
 };


### PR DESCRIPTION
By gitflow methodology (https://danielkummer.github.io/git-flow-cheatsheet/) all feature/fix branches should be merged to develop when finishing and release/hotfix branches should be finished to development and production.

For now, `gflow` finishes them to production, even when they were created from development.

I checked the code, and there is some weird stuff in `get-ancestor-branch.js` file.
1) This code does not work
```
    const paths = currentBranch.split('/'); // ["fix", "defaultBranchForNew"]

    paths.splice(-2); // []

   const fromBranch = paths.join('/'); // ""
```
Here paths will be always empty array, because usually branch names have only one "/" sign in the branch name (ex. fix/defaultBranchForNew), so fromBranch will be always an empty string.

And I didn't get what does `getBranches` function do. Maybe it is better to put some comments about it.

2) `return config.remoteProduction;` ok, the code up does not work, but why we return production branch by default?
